### PR TITLE
fix two bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 /captures
 .externalNativeBuild
 library/
-gradle/wrapper/gradle-wrapper.properties

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Perfect Tune Library
+
+[![](https://jitpack.io/v/Lokarzz/perfectTune.svg)](https://jitpack.io/#Lokarzz/perfectTune)
+
 Android Library generate simple audio tune of different frequency with no sweat.
 generating audio tune is not that easy. This library will help you.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then add the library by including it in one of your dependencies
 
 ```sh
 dependencies {
-    implementation 'com.github.karlotoy:perfectTune:1.0.3'
+    implementation 'com.github.Lokarzz:perfectTune:1.0.4'
 }
 ```
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Aug 27 11:58:06 MSK 2021
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/perfectune/src/main/java/com/karlotoy/perfectune/instance/PerfectTune.java
+++ b/perfectune/src/main/java/com/karlotoy/perfectune/instance/PerfectTune.java
@@ -39,7 +39,7 @@ public class PerfectTune {
         }
     }
 
-    public double getAmplitude() { return tuneAmp; }
+    public int getTuneAmplitude() { return tuneAmp; }
 
     public void stopTune(){
         if(tuneThread != null){


### PR DESCRIPTION
Hello again, @Lokarzz. Thank you for merging my previous request #4.

Unfortunately, I made a couple of mistakes:
1. I did not check the jitpack build, and now it turned out that for v1.0.3 it fails (https://jitpack.io/#Lokarzz/perfectTune). It also fails for 1.0.2; I do not know how it worked earlier. Anyway, the solution was to un-ignore `gradle/wrapper/gradle-wrapper.properties`, which I've done.
2. In Java code, I implemented the getter signature for amplitude the wrong way (which I discovered while trying to use the property access syntax in Kotlin).

Now I've fixed this (the build is passing: https://jitpack.io/#braille-systems/perfectTune/bc09ec2890). May you please merge this patch and bump the version to 1.0.4  (I've already tweaked the readme)?

My apologies, I should have fixed this before the first request, this time I've double-checked everything.
